### PR TITLE
feat(InlineEditor): add select option to edit method

### DIFF
--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -424,7 +424,7 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
     }
 
     // Method to display the inline editor form and hide the <a> element
-    public edit({ editing = true, doFocus = true, event }: EditOptions = {}) {
+    public edit({ editing = true, focus = true, select = false, event }: EditOptions = {}) {
         this.state = this.state.newState({
             ...this.state.getState(),
             editing,
@@ -439,9 +439,14 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
             });
         }
 
-        if (editing && doFocus) {
+        if (editing && focus) {
             this.inputInstance.focus();
         }
+
+        if (editing && select) {
+            this.inputInstance.select();
+        }
+
     }
 
     public save({ event, state: hotState }: InlineEditorEvent) {

--- a/src/inputs/input-base.ts
+++ b/src/inputs/input-base.ts
@@ -187,6 +187,10 @@ export class InputBase implements OnInit, OnChanges, DoCheck,
         setTimeout(() => this.renderer.invokeElementMethod(this.inputElement, "focus", []));
     }
 
+    public select() {
+        setTimeout(() => this.renderer.invokeElementMethod(this.inputElement, "select", []));
+    }
+
     protected updateState(newState: InlineEditorState) {
         const { empty: wasEmpty, disabled: wasDisabled } = this.state.getState();
 

--- a/src/types/edit-options.interface.ts
+++ b/src/types/edit-options.interface.ts
@@ -1,5 +1,6 @@
 export interface EditOptions {
     editing?: boolean;
-    doFocus?: boolean;
+    focus?: boolean;
+    select?: boolean;
     event?: Event;
 }


### PR DESCRIPTION
In reference to https://github.com/qontu/ngx-inline-editor/issues/58#issuecomment-307801805
I have implemented the select option to use in edit method and rename doFocus option to focus