### PR TITLE
Added fields name to state object

### DIFF
--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -317,6 +317,7 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
 
         this.state = new InlineEditorState({
             value: "",
+            name: this.name != null ? this.name : ""
         });
 
         this.service = new InlineEditorService(this.events, { ...this.config });

--- a/src/inputs/input-base.ts
+++ b/src/inputs/input-base.ts
@@ -27,6 +27,7 @@ export class InputBase implements OnInit, OnChanges, DoCheck,
             value: "",
             empty: true,
             disabled: this.config.disabled,
+            name: this.config.name != null ? this.config.name : ""
         });
 
         this.service.onUpdateStateOfService.emit(this.state.clone());

--- a/src/inputs/input-base.ts
+++ b/src/inputs/input-base.ts
@@ -42,6 +42,7 @@ export class InputBase implements OnInit, OnChanges, DoCheck,
                 this.updateState(this.state.newState({
                     ...newState,
                     empty: this.isEmpty(newState.value),
+                    name: this.config.name
                 }));
 
                 this.service.events.internal.onUpdateStateOfParent.emit(this.state.clone());

--- a/src/types/inline-editor-state.class.ts
+++ b/src/types/inline-editor-state.class.ts
@@ -34,7 +34,7 @@ export class InlineEditorState {
     }
 
     public getState(): InlineEditorStateOptions {
-        const { value, editing, disabled, empty } = this;
+        const { value, editing, disabled, empty, name } = this;
 
         return {
             value,

--- a/src/types/inline-editor-state.class.ts
+++ b/src/types/inline-editor-state.class.ts
@@ -3,6 +3,7 @@ export interface InlineEditorStateOptions {
     editing?: boolean;
     disabled?: boolean;
     empty?: boolean;
+    name: string;
 }
 
 export class InlineEditorState {
@@ -12,17 +13,20 @@ export class InlineEditorState {
         disabled = false,
         editing = false,
         empty = false,
-    }: InlineEditorStateOptions = { value: "" }) {
+        name
+    }: InlineEditorStateOptions = { value: "", name: "" }) {
         this.value = value;
         this.disabled = disabled;
         this.editing = editing;
         this.empty = empty;
+        this.name = name;
     }
 
     private empty: boolean;
     private value: any;
     private disabled: boolean;
     private editing: boolean;
+    private name: string;
 
     public newState(state: InlineEditorState | InlineEditorStateOptions) {
         return new InlineEditorState(state instanceof InlineEditorState ?
@@ -37,6 +41,7 @@ export class InlineEditorState {
             editing,
             disabled,
             empty,
+            name
         };
     }
 


### PR DESCRIPTION
In many cases you have single save-function, that is referenced by multiple onSave() events. In these cases you want to know which field actually passed the save event. It was possible to fetch this info through DOM, but it was bit too complex.

Added optional "name" property to state object, which can be easily used to identify which field sent the event. 

I tested this code in my own project.