### PR TITLE
feat(InlineEditorEvent): Add instance prop when emit to client

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/src/inline-editor.component.ts
+++ b/src/inline-editor.component.ts
@@ -20,7 +20,14 @@ import { InputDatetimeComponent } from "./inputs/input-datetime.component";
 import { Subscription } from "rxjs/Subscription";
 import { SelectOptions } from "./types/select-options.interface";
 import { InlineEditorError } from "./types/inline-editor-error.interface";
-import { InlineEditorEvent, InternalEvent, Events, InternalEvents, ExternalEvents } from "./types/inline-editor-events.class";
+import {
+    InlineEditorEvent,
+    InternalEvent,
+    Events,
+    InternalEvents,
+    ExternalEvents,
+    ExternalEvent,
+} from "./types/inline-editor-events.class";
 import { InlineEditorState, InlineEditorStateOptions } from "./types/inline-editor-state.class";
 import { EditOptions } from "./types/edit-options.interface";
 import { InputType } from "./types/input-type.type";
@@ -342,7 +349,7 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
 
         this.subscriptions.onChangeSubcription = this.events.internal.onChange.subscribe(
             ({ event, state }: InternalEvent) => {
-                 if (this.config.saveOnChange) {
+                if (this.config.saveOnChange) {
                     this.saveAndClose({
                         event,
                         state: state.getState(),
@@ -444,8 +451,8 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
     registerOnChange(refreshNGModel: (_: any) => void) {
         this.refreshNGModel = refreshNGModel;
     }
-    registerOnTouched() {
-    }
+
+    registerOnTouched() { }
 
     // Method to display the inline editor form and hide the <a> element
     public edit({ editing = true, focus = true, select = false, event }: EditOptions = {}) {
@@ -473,7 +480,7 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
 
     }
 
-    public save({ event, state: hotState }: InlineEditorEvent) {
+    public save({ event, state: hotState }: ExternalEvent) {
         const prevState = this.state.getState();
 
         const state = {
@@ -496,14 +503,14 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
         }
     }
 
-    public saveAndClose(outsideEvent: InlineEditorEvent) {
+    public saveAndClose(outsideEvent: ExternalEvent) {
         this.save(outsideEvent);
 
         this.edit({ editing: false });
     }
 
     // Method to reset the editable value
-    public cancel(outsideEvent: InlineEditorEvent) {
+    public cancel(outsideEvent: ExternalEvent) {
         this.edit({ editing: false });
         this.emit(this.onCancel, outsideEvent);
     }
@@ -607,7 +614,15 @@ export class InlineEditorComponent implements OnInit, AfterContentInit, OnDestro
     }
 
 
-    private emit(event: EventEmitter<InlineEditorEvent | any>, data: InlineEditorEvent) {
-        event.emit(this.config.onlyValue ? data.state.value : data);
+    private emit(event: EventEmitter<InlineEditorEvent | any>, data: ExternalEvent) {
+        if (this.config.onlyValue) {
+            event.emit(data.state.value);
+        } else {
+            (event as EventEmitter<InlineEditorEvent>)
+                .emit({
+                    ...data,
+                    instance: this,
+                });
+        }
     }
 }

--- a/src/inline-editor.module.ts
+++ b/src/inline-editor.module.ts
@@ -4,15 +4,15 @@ import { FormsModule } from "@angular/forms";
 
 import { InlineEditorComponent } from "./inline-editor.component";
 import {
-  InputTimeComponent,
-  InputDateComponent,
-  InputDatetimeComponent,
-  InputNumberComponent,
-  InputRangeComponent,
-  InputPasswordComponent,
-  InputSelectComponent,
-  InputTextareaComponent,
-  InputTextComponent,
+    InputTimeComponent,
+    InputDateComponent,
+    InputDatetimeComponent,
+    InputNumberComponent,
+    InputRangeComponent,
+    InputPasswordComponent,
+    InputSelectComponent,
+    InputTextareaComponent,
+    InputTextComponent,
 } from "./inputs/index";
 import { InputBase } from "./inputs/input-base";
 
@@ -23,23 +23,23 @@ export { InputBase } from "./inputs/input-base";
 export { InlineEditorEvent } from "./types/inline-editor-events.class";
 
 const EXPORTS = [
-  InputBase,
-  InputTextComponent,
-  InputNumberComponent,
-  InputPasswordComponent,
-  InputRangeComponent,
-  InputTextareaComponent,
-  InputSelectComponent,
-  InputDateComponent,
-  InputTimeComponent,
-  InputDatetimeComponent,
+    InputBase,
+    InputTextComponent,
+    InputNumberComponent,
+    InputPasswordComponent,
+    InputRangeComponent,
+    InputTextareaComponent,
+    InputSelectComponent,
+    InputDateComponent,
+    InputTimeComponent,
+    InputDatetimeComponent,
 
-  InlineEditorComponent,
+    InlineEditorComponent,
 ];
 
 @NgModule({
-  imports: [CommonModule, FormsModule],
-  declarations: EXPORTS,
-  exports: [InlineEditorComponent],
+    imports: [CommonModule, FormsModule],
+    declarations: EXPORTS,
+    exports: [InlineEditorComponent],
 })
 export class InlineEditorModule { }

--- a/src/types/inline-editor-events.class.ts
+++ b/src/types/inline-editor-events.class.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "@angular/core";
 import { InlineEditorError } from "./inline-editor-error.interface";
 import { InlineConfig } from "../types/inline-configs";
 import { InlineEditorState, InlineEditorStateOptions } from "./inline-editor-state.class";
+import { InlineEditorComponent } from "../inline-editor.component";
 
 export interface Events {
     internal: InternalEvents;
@@ -48,4 +49,6 @@ export interface ExternalEvent {
     state: InlineEditorStateOptions;
 }
 
-export type InlineEditorEvent = ExternalEvent;
+export interface InlineEditorEvent extends ExternalEvent {
+    instance: InlineEditorComponent;
+}


### PR DESCRIPTION
It's related to https://github.com/qontu/ngx-inline-editor/pull/72. It resolves when you need to know what inline-editor triggers the event (Like I commented here https://github.com/qontu/ngx-inline-editor/pull/72#issuecomment-310117289)