### PR TITLE
Null input fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "gulp-inline-ng2-template": "^4.0.0",
     "gulp-ngc": "^0.3.2",
     "gulp-rename": "^1.2.2",
-    "gulp-rollup": "^2.14.0",
+    "gulp-rollup": "2.14.0",
     "gulp-typescript": "^3.2.2",
     "jasmine-core": "^2.6.4",
     "karma": "^1.7.0",

--- a/src/inputs/input-base.ts
+++ b/src/inputs/input-base.ts
@@ -162,7 +162,7 @@ export class InputBase implements OnInit, OnChanges, DoCheck,
         const { value } = this.state.getState();
 
         if (this.canTestRegex(this.config)) {
-            if (!new RegExp(this.config.pattern as string).test(value)) {
+            if (!new RegExp(this.config.pattern as string).test((value !== null && value !== false) ? value : ''))  {
                 errs.push({
                     type: "PATTERN_ERROR",
                     message: "Test pattern has failed",
@@ -172,7 +172,7 @@ export class InputBase implements OnInit, OnChanges, DoCheck,
 
         if (this.canTestLength(this.config)) {
             const { min, max } = this.config;
-            const length = this.isNumeric ? Number(value) : value.length;
+            const length = value ? (this.isNumeric ? Number(value) : value.length) : 0;
 
             if (length < min || length > max) {
                 errs.push({

--- a/src/inputs/input-base.ts
+++ b/src/inputs/input-base.ts
@@ -162,7 +162,7 @@ export class InputBase implements OnInit, OnChanges, DoCheck,
         const { value } = this.state.getState();
 
         if (this.canTestRegex(this.config)) {
-            if (!new RegExp(this.config.pattern as string).test((value !== null && value !== false) ? value : ''))  {
+            if (!new RegExp(this.config.pattern as string).test(value != null && value !== false ? value : ''))  {
                 errs.push({
                     type: "PATTERN_ERROR",
                     message: "Test pattern has failed",


### PR DESCRIPTION
First commit prevents errors / false-positives on length and RegExp checks if input value is `null` or `false`. 

2nd commit updates package.json to prevent build error/conflict with `gulp-rollup@2.15.0`