### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The `$event` argument will be the value return of the input send.
 
 ```HTML
  <inline-editor
-        type="textArea"
+        type="textarea"
         [(ngModel)]="editableTextArea"
         (onSave)="saveEditable($event)"
         name="editableTextArea"


### PR DESCRIPTION
type="textArea" changed to type="textarea" due to the following exception:
mobx.module.js:3281 [mobx] Encountered an uncaught exception that was thrown by a reaction or observer component, in: 'Reaction[TreeNodeCollectionComponent.detectChanges()] Error: That type does not exist or it is not implemented yet!
    at InlineEditorComponent.getComponentType (ngx-inline-editor.es5.js:1441)
    at InlineEditorComponent.generateComponent (ngx-inline-editor.es5.js:1450)
    at InlineEditorComponent.ngAfterContentInit (ngx-inline-editor.es5.js:1324)
    at callProviderLifecycles (core.js:12682)
    at callElementProvidersLifecycles (core.js:12656)
    at callLifecycleHooksChildrenFirst (core.js:12639)
    at checkAndUpdateView (core.js:13789)
    at callViewAction (core.js:14136)
    at execEmbeddedViewsAction (core.js:14094)
    at checkAndUpdateView (core.js:13786)