### PR TITLE
Make inline editor icon work with Font Awesome 4+

### DIFF
--- a/src/inline-editor.component.html
+++ b/src/inline-editor.component.html
@@ -8,7 +8,7 @@
           (click)="saveAndClose({ event: $event, state: service.getState() })">
           <span class="fa fa-check"></span>
       </button>
-      <button class="btn btn-xs btn-danger c-inline-editor" (click)="cancel({ event: $event, state: service.getState() })"><span class="fa fa-remove"></span> </button>
+      <button class="btn btn-xs btn-danger c-inline-editor" (click)="cancel({ event: $event, state: service.getState() })"><span class="fa fa-times"></span> </button>
       </span>
 
     </div>


### PR DESCRIPTION
fa-remove was renamed to fa-times to the newer font awesome versions